### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/itbetechnology/a7a89a13-06d4-4ba0-8530-32f84d1f3066/7a6ce825-0885-4a0b-a7f7-330c92ef9c3a/_apis/work/boardbadge/d1f57083-0395-497b-b60d-a9920bda177b)](https://dev.azure.com/itbetechnology/a7a89a13-06d4-4ba0-8530-32f84d1f3066/_boards/board/t/7a6ce825-0885-4a0b-a7f7-330c92ef9c3a/Microsoft.RequirementCategory)
 This is a change made to the first line of the README.md file of new-branch-2--the same line in which a change was made to the README.md file of new-branch-1.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/itbetechnology/a7a89a13-06d4-4ba0-8530-32f84d1f3066/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.